### PR TITLE
Add logic to release gem via rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # BulletTrain::Release
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/bullet_train/release`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+An isolated layer for handling Bullet Train package releases in one place.
 
 ## Installation
 
@@ -16,7 +14,16 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 ## Usage
 
-TODO: Write usage instructions here
+Navigate to the gem of your choice and run the following to release your gem:
+```shell
+# ⚠️ Running this command will push your changes to GitHub!
+$ rake app:bullet_train:release
+
+# If you just want to test run the logic and build
+# the packages without pushing your changes, add `dry-run`
+$ rake app:bullet_train:release[dry-run]
+```
+
 
 ## Development
 
@@ -26,7 +33,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/bullet_train-release.
+Bug reports and pull requests are welcome on GitHub at https://github.com/bullet-train-co/bullet_train-release.
 
 ## License
 

--- a/bullet_train-release.gemspec
+++ b/bullet_train-release.gemspec
@@ -8,17 +8,17 @@ Gem::Specification.new do |spec|
   spec.authors = ["Andrew Culver", "Gabriel Zayas"]
   spec.email = ["andrew.culver@gmail.com", "g-zayas@hotmail.com"]
 
-  spec.summary = "TODO: Write a short summary, because RubyGems requires one."
-  spec.description = "TODO: Write a longer description or delete this line."
-  spec.homepage = "TODO: Put your gem's website or public repo URL here."
+  spec.summary = "A gem for releasing Bullet Train packages."
+  spec.description = "An isolated layer for handling Bullet Train package releases in one place."
+  spec.homepage = "https://github.com/bullet-train-co/bullet_train-release"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 2.6.0"
 
   spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata["source_code_uri"] = "https://github.com/bullet-train-co/bullet_train-release"
+  spec.metadata["changelog_uri"] = "https://github.com/bullet-train-co/bullet_train-release/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -31,9 +31,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
-
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
+  spec.add_dependency "railties"
+  spec.add_dependency "bump"
 end

--- a/lib/bullet_train/release.rb
+++ b/lib/bullet_train/release.rb
@@ -1,10 +1,84 @@
 # frozen_string_literal: true
 
 require_relative "release/version"
+require "rails/railtie"
 
 module BulletTrain
   module Release
     class Error < StandardError; end
-    # Your code goes here...
+
+    class LoadTasks < Rails::Railtie
+      rake_tasks do
+        rake_file_path = "#{(__dir__).gsub("/lib/bullet_train", "")}/tasks/bullet_train-release.rake"
+        load rake_file_path
+      end
+    end
+
+    def self.run(dry_run)
+      unless `git branch | grep main`.chomp == "* main"
+        puts "You can only release from the `main` branch."
+        exit
+      end
+
+      puts "Checking whether we're up-to-date with `origin/main`."
+
+      stream "git fetch origin"
+      puts output = `git merge origin main`
+
+      unless output.include?("Already up to date")
+        puts "Sorry, `main` needed to be up-to-date with `origin/main` before we release, and it looks like it wasn't. We attempted a merge, but you should confirm that went OK before running `rake app:bullet_train:release` again!"
+        exit
+      end
+
+      puts "Bumping Ruby gem version."
+      puts output = `bump patch`
+      version = output.chomp.lines.last.chomp
+      puts "Bumped to #{version}."
+
+      # Update the `package.json` version.
+      puts "Bumping npm package version."
+      text = File.read("package.json")
+      new_contents = text.gsub(/\"version\": \".*\"/, "\"version\": \"#{version}\"")
+      File.open("package.json", "w") { |file| file.puts new_contents }
+      unless dry_run
+        `git add ./package.json`
+        stream "git commit -m \"Bumping npm package to #{version}.\""
+      end
+
+      unless dry_run
+        puts "OK! Versions are all bumped. Pushing those to GitHub."
+        stream "git push origin main"
+      end
+
+      puts "Now we'll build the Ruby gem."
+      puts output = `gem build`
+      gem_file = output.chomp.lines.last.chomp.split.last
+      puts gem_file
+
+      puts "Now we'll build the npm package."
+      puts `yarn build`
+      puts output = `yarn pack`
+      npm_file = output.chomp.lines[1].split("/").last.split("\"").first
+      puts npm_file
+
+      puts "OK, this last piece we can't do manually (because of 2FA) so copy and the following:"
+      puts ""
+      puts "  gem push #{gem_file}"
+      puts "  yarn publish #{npm_file} --new-version #{version}"
+      puts "  rm #{gem_file} #{npm_file}"
+      puts ""
+    end
+
+    private
+
+    def self.stream(command, prefix = "  ")
+      puts ""
+      IO.popen(command) do |io|
+        while (line = io.gets) do
+          puts "#{prefix}#{line}"
+        end
+      end
+      puts ""
+    end
   end
 end

--- a/lib/bullet_train/release.rb
+++ b/lib/bullet_train/release.rb
@@ -30,19 +30,21 @@ module BulletTrain
         exit
       end
 
-      puts "Bumping Ruby gem version."
-      puts output = `bump patch`
-      version = output.chomp.lines.last.chomp
-      puts "Bumped to #{version}."
-
-      # Update the `package.json` version.
-      puts "Bumping npm package version."
-      text = File.read("package.json")
-      new_contents = text.gsub(/\"version\": \".*\"/, "\"version\": \"#{version}\"")
-      File.open("package.json", "w") { |file| file.puts new_contents }
       unless dry_run
+        puts "Bumping Ruby gem version."
+        puts output = `bump patch`
+        version = output.chomp.lines.last.chomp
+        puts "Bumped to #{version}."
+
+        # Update the `package.json` version.
+        puts "Bumping npm package version."
+        text = File.read("package.json")
+        new_contents = text.gsub(/\"version\": \".*\"/, "\"version\": \"#{version}\"")
+        File.open("package.json", "w") { |file| file.puts new_contents }
         `git add ./package.json`
         stream "git commit -m \"Bumping npm package to #{version}.\""
+      else
+        puts "Skipping step to bump Ruby gem version and package.json version."
       end
 
       unless dry_run

--- a/tasks/bullet_train-release.rake
+++ b/tasks/bullet_train-release.rake
@@ -1,0 +1,7 @@
+namespace :bullet_train do
+  desc "Release your package as both a Ruby gem and an npm package."
+  task :release, ['flag'] do |task, args|
+    dry_run = args.to_a.first == "dry-run"
+    BulletTrain::Release.run(dry_run)
+  end
+end


### PR DESCRIPTION
・Closes [#35](https://github.com/bullet-train-co/bullet_train-base/issues/35) in [bullet_train-base](https://github.com/bullet-train-co/bullet_train-base)

### Use
Add this to the Gemfile (as opposed to the gemspec) and bundle in whichever package you want to release.
```ruby
gem "bullet_train-release", git: "git@github.com:bullet-train-co/bullet_train-release.git", branch: "features/add-basic-release-logic"
```

Then run the following:
```shell
# Pushes changes to GitHub
$ rake app:bullet_train:release
# Skips git commit/push commands
$ rake app:bullet_train:release[dry-run]
```

### Details
Instead of running `bin/release`, we just include the gem in the Gemfile, run the task in the gem's directory and delete `bin/release` altogether. This makes it a little easier to manage everything in just one place without having to configure anything in the gem we want to release. If we need a `bin/release` file though, I can move the rake task over there.

Also, the `bump` gem's executable wasn't working when trying to run `bump patch` (you can uninstall the gem and then try running `rake app:bullet_train:release`). It would install the gem itself which is confirmed in the terminal, but it wouldn't run the CLI command. For that reason, I added `bump` to the dependencies in the gemspec.

### Warnings and errors

There were some warnings, but besides that the only thing I wasn't sure if I should worry about was this error when trying to build an npm package:
```
/bin/sh: 1: rimraf: not found
error Command failed with exit code 127.
```
It seems to be something specific to the `package.json` file in the gem I was working in, but if not I'll take a deeper look if needed.